### PR TITLE
crash fix

### DIFF
--- a/enet server test/enet server test.cpp
+++ b/enet server test/enet server test.cpp
@@ -342,6 +342,9 @@ public:
 		memcpy(packet_data + 16, &CharState, 4);
 		memcpy(packet_data + 24, &delay, 4);
 	};
+	~gamepacket_t() {
+		delete[] packet_data;
+	}
 
 	void Insert(string a) {
 		byte* data = new byte[len + 2 + a.length() + 4];
@@ -423,7 +426,6 @@ public:
 	void CreatePacket(ENetPeer* peer) {
 		ENetPacket* packet = enet_packet_create(packet_data, len, 1);
 		enet_peer_send(peer, 0, packet);
-		delete[] packet_data;
 	}
 };
 


### PR DESCRIPTION
If you want to send the same packet to multiple peers, prepare for a crash because that data has already been deleted. My proposal: delete packet_data when the destructor is called.