### PR TITLE
Update CDNContent

### DIFF
--- a/enet server test/enet server test.cpp
+++ b/enet server test/enet server test.cpp
@@ -2625,7 +2625,7 @@ void loadConfig() {
 			cout << "Config loaded." << endl;
 		} catch (...) {
 			cout << "Invalid Config, Fixing..." << endl;
-			string config_contents = "{ \"port\": 17091, \"cdn\": \"0098/CDNContent77/cache/\" }";
+			string config_contents = "{ \"port\": 17091, \"cdn\": \"0098/CDNContent78/cache/\" }";
 
 			ofstream myfile1;
 			myfile1.open("config.json");
@@ -2643,7 +2643,7 @@ void loadConfig() {
 		}
 	} else {
 		cout << "Config not found, Creating..." << endl;
-		string config_contents = "{ \"port\": 17091, \"cdn\": \"0098/CDNContent77/cache/\" }";
+		string config_contents = "{ \"port\": 17091, \"cdn\": \"0098/CDNContent78/cache/\" }";
 
 		ofstream myfile1;
 		myfile1.open("config.json");


### PR DESCRIPTION
The CDNContent77 may cause a 404 not found HTTP error because it is missing files (not up to date)